### PR TITLE
Add fab params to mirror utm, hubspot and segment params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,14 @@ const searchDomains = [
 const productDomains = [
     "nudgesecurity.io"
 ]
+const fabParameterMapping = {
+    'utm_medium': 'fab_m',
+    'utm_source': 'fab_s',
+    'utm_content': 'fab_co',
+    'utm_campaign': 'fab_ca',
+    'utm_term': 'fab_t',
+    'utm_email': 'fab_e'
+};
 
 export function process_utm_data() {
     var queryString = window.location.search;
@@ -129,9 +137,17 @@ export function processHrefTrialParams(element, includeAnalytics = false, hub_co
         if (utm_cookie) {
             var cached = new URLSearchParams(utm_cookie);
             for (const key of cached.keys()) {
-                url.searchParams.set(key, cached.get(key))
+                var value = cached.get(key)
+                url.searchParams.set(key, value)
+
                 if (key === 'gclid') {
                     gclid = cached.get(key)
+                }
+
+                // Set parameter if found in look up map
+                var fabKey = fabParameterMapping[key];
+                if (fabKey) {
+                    url.searchParams.set(fabKey, value);
                 }
             }
         }
@@ -140,6 +156,7 @@ export function processHrefTrialParams(element, includeAnalytics = false, hub_co
             let user = analytics.user();
             if (user) {
                 url.searchParams.set("ajs_aid", user.anonymousId());
+                url.searchParams.set("fab_seg", user.anonymousId());
             }
         }
         if (hub_cookie == null) {
@@ -147,6 +164,7 @@ export function processHrefTrialParams(element, includeAnalytics = false, hub_co
         }
         if (hub_cookie && hub_cookie !== '') {
             url.searchParams.set("hub", hub_cookie);
+            url.searchParams.set("fab_hsc", hub_cookie);
         }
         var current_path = get_current_path();
         url.searchParams.set('submission_url', current_path)

--- a/test/update_trial_links.test.js
+++ b/test/update_trial_links.test.js
@@ -70,7 +70,7 @@ describe("Update Trial Links", () => {
         expect(get_utm_cookie()).toBe(null);
         expect(global.analytics.track.mock.calls.length).toBe(2);
         expect(global.analytics.track.mock.calls[0][0]).toBe('trial_click_leaving_com');
-        expect(global.analytics.track.mock.calls[0][1]).toStrictEqual({'target':'https://nudgesecurity.io/login?utm_campaign=new&utm_source=email&utm_medium=always&utm_content=read&utm_term=on&gclid=123&referring_domain=www.google.com&landing_url=%2Fproduct%2Fsoc2&ajs_event=trial_click_io_landing&hub=foo&submission_url=%2Fproduct%2Fsoc2&ajs_aid=15122412'});
+        expect(global.analytics.track.mock.calls[0][1]).toStrictEqual({'target':'https://nudgesecurity.io/login?utm_campaign=new&utm_source=email&fab_s=email&utm_medium=always&fab_m=always&utm_content=read&fab_co=read&utm_term=on&fab_t=on&gclid=123&fab_ca=new&referring_domain=www.google.com&landing_url=%2Fproduct%2Fsoc2&ajs_event=trial_click_io_landing&hub=foo&fab_hsc=foo&submission_url=%2Fproduct%2Fsoc2&ajs_aid=15122412&fab_seg=15122412',});
         expect(global.analytics.track.mock.calls[1][0]).toBe('trial_click');
         expect(global.analytics.track.mock.calls[1][1]).toStrictEqual({'submission-url':'/product/soc2','gclid':'123'});
 


### PR DESCRIPTION
See: https://nudgesecurity.atlassian.net/browse/NF-8390

This will include mirrored parameters for the utm, segment cookie and hubspot cookie parameters to try and alleviate cases where they seem to be getting stripped. Their is a backend change that handles this on the product side as well.