### PR TITLE
Nf 10883 login button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist/index.js
 /dist/module.js
 *.iml
+/coverage/

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,8 @@ function get_current_path() {
 export function processHrefTrialParams(
     element,
     includeAnalytics = false,
-    hub_cookie = null
+    hub_cookie = null,
+    includeConversionData = true
 ) {
     var href = element.getAttribute('href')
     if (href && href.startsWith('http')) {
@@ -185,15 +186,17 @@ export function processHrefTrialParams(
             url.searchParams.set('hub', hub_cookie)
             url.searchParams.set('fab_hsc', hub_cookie)
         }
-        var current_path = get_current_path()
+        var current_path = get_current_path();
         url.searchParams.set('submission_url', current_path)
 
         const biscotti_value = get_encoded_parameters(url)
         url.searchParams.set('biscotti', biscotti_value)
 
-        const entries = Object.entries(window.trial_conversions)
-        for (const [attr, value] of entries) {
-            element.setAttribute(attr, value)
+        if (includeConversionData) {
+            const entries = Object.entries(window.trial_conversions)
+            for (const [attr, value] of entries) {
+                element.setAttribute(attr, value)
+            }
         }
         element.setAttribute(`data-property-submission-url`, current_path)
         if (gclid) {
@@ -210,6 +213,15 @@ export function selectAndUpdateTrialButtons() {
             delete_utm_cookie()
             var url = e.target.getAttribute('href')
             track_event('trial_click_leaving_com', { target: url })
+        })
+    })
+}
+
+export function selectAndUpdateLoginButtons() {
+    $('[login-button]').each(function () {
+        processHrefTrialParams($(this)[0], false, null, false)
+        $(this).on('click', (e) => {
+            delete_utm_cookie()
         })
     })
 }
@@ -296,6 +308,7 @@ export function updateTrialButtonAJSID() {
 export function configure() {
     process_utm_data()
     selectAndUpdateTrialButtons()
+    selectAndUpdateLoginButtons()
     selectAndUpdateDataAnalytics()
     selectAndUpdateLinkedInConversion()
     selectAndUpdateLinkedInConversion2()

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ export function process_utm_data() {
     setCookie(newList)
 }
 
-function get_current_path() {
+export function get_current_path() {
     var current_path = new URL(window.location).pathname
     if (current_path === '/') {
         current_path = 'home'
@@ -151,6 +151,7 @@ export function processHrefTrialParams(
     var href = element.getAttribute('href')
     if (href && href.startsWith('http')) {
         var url = new URL(href)
+        var originalParams = new URLSearchParams(url.search)
 
         var utm_cookie = get_utm_cookie()
         var gclid = null
@@ -158,7 +159,10 @@ export function processHrefTrialParams(
             var cached = new URLSearchParams(utm_cookie)
             for (const key of cached.keys()) {
                 var value = cached.get(key)
-                url.searchParams.set(key, value)
+                // Only set UTM params if they're not already in the URL
+                if (!originalParams.has(key)) {
+                    url.searchParams.set(key, value)
+                }
 
                 if (key === 'gclid') {
                     gclid = cached.get(key)

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,6 @@ export function processHrefTrialParams(
     var href = element.getAttribute('href')
     if (href && href.startsWith('http')) {
         var url = new URL(href)
-        var originalParams = new URLSearchParams(url.search)
 
         var utm_cookie = get_utm_cookie()
         var gclid = null
@@ -159,10 +158,7 @@ export function processHrefTrialParams(
             var cached = new URLSearchParams(utm_cookie)
             for (const key of cached.keys()) {
                 var value = cached.get(key)
-                // Only set UTM params if they're not already in the URL
-                if (!originalParams.has(key)) {
-                    url.searchParams.set(key, value)
-                }
+                url.searchParams.set(key, value)
 
                 if (key === 'gclid') {
                     gclid = cached.get(key)
@@ -190,7 +186,7 @@ export function processHrefTrialParams(
             url.searchParams.set('hub', hub_cookie)
             url.searchParams.set('fab_hsc', hub_cookie)
         }
-        var current_path = get_current_path();
+        var current_path = get_current_path()
         url.searchParams.set('submission_url', current_path)
 
         const biscotti_value = get_encoded_parameters(url)

--- a/test/login_button.test.js
+++ b/test/login_button.test.js
@@ -33,8 +33,7 @@ describe("Login Button Tests", () => {
         // Set up document with test buttons
         document.body.innerHTML = `
             <div>
-                <a login-button id="login-button-1" href="https://nudgesecurity.io/login?utm_campaign=blah"></a>
-                <a login-button id="login-button-2" href="https://nudgesecurity.io/login"></a>
+                <a login-button id="login-button-1" href="https://nudgesecurity.io/login"></a>
                 <a login-button id="login-button-bad" href="#login"></a>
             </div>
         `;

--- a/test/login_button.test.js
+++ b/test/login_button.test.js
@@ -9,7 +9,7 @@ import {set_up_app} from "./environment.mock";
 import $ from "jquery";
 import Cookies from 'js-cookie';
 
-import {get_utm_cookie, delete_utm_cookie, process_utm_data, setCookie, get_current_path, processHrefTrialParams, selectAndUpdateLoginButtons} from "../dist/module";
+import {get_utm_cookie, delete_utm_cookie, process_utm_data, setCookie, selectAndUpdateLoginButtons} from "../dist/module";
 
 describe("Login Button Tests", () => {
     beforeAll(() => {
@@ -48,7 +48,6 @@ describe("Login Button Tests", () => {
         console.log('Initial state:', {
             href: window.location.href,
             pathname: window.location.pathname,
-            currentPath: get_current_path(),
             buttonHref: $('#login-button-1')[0].getAttribute('href')
         });
     });
@@ -74,7 +73,7 @@ describe("Login Button Tests", () => {
         const href = button.getAttribute('href');
         const url = new URL(href);
         // Login buttons should preserve original UTM parameters
-        expect(url.searchParams.get('utm_campaign')).toBe('blah');
+        expect(url.searchParams.get('utm_campaign')).toBe('new');
         // But should still add submission URL
         expect(url.searchParams.get('submission_url')).toBe('/product/soc2');
     });

--- a/test/login_button.test.js
+++ b/test/login_button.test.js
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://nudgesecurity.com/product/soc2?utm_campaign=new&utm_source=email&utm_content=read&utm_medium=always&utm_term=on&gclid=123" ,"referrer":"https://www.google.com/"}
+ */
+'use strict';
+/*eslint-env browser */
+import './environment.mock'
+import {set_up_app} from "./environment.mock";
+import $ from "jquery";
+import Cookies from 'js-cookie';
+
+import {get_utm_cookie, delete_utm_cookie, process_utm_data, setCookie, get_current_path, processHrefTrialParams, selectAndUpdateLoginButtons} from "../dist/module";
+
+describe("Login Button Tests", () => {
+    beforeAll(() => {
+        // Set up window location and document
+        const baseUrl = "https://nudgesecurity.com/product/soc2";
+        const mockUrl = new URL(baseUrl);
+
+        // Mock window.location to work with URL constructor
+        delete window.location;
+        window.location = {
+            href: mockUrl.href,
+            search: "?utm_campaign=new&utm_source=email",
+            pathname: mockUrl.pathname,
+            host: mockUrl.host,
+            hostname: mockUrl.hostname,
+            protocol: mockUrl.protocol,
+            origin: mockUrl.origin,
+            toString: function() { return this.href; }
+        };
+
+        // Set up document with test buttons
+        document.body.innerHTML = `
+            <div>
+                <a login-button id="login-button-1" href="https://nudgesecurity.io/login?utm_campaign=blah"></a>
+                <a login-button id="login-button-2" href="https://nudgesecurity.io/login"></a>
+                <a login-button id="login-button-bad" href="#login"></a>
+            </div>
+        `;
+
+        // Initialize the app after DOM setup
+        process_utm_data();
+        selectAndUpdateLoginButtons();
+        set_up_app();
+
+        // Debug initialization
+        console.log('Initial state:', {
+            href: window.location.href,
+            pathname: window.location.pathname,
+            currentPath: get_current_path(),
+            buttonHref: $('#login-button-1')[0].getAttribute('href')
+        });
+    });
+
+    // Test URL parameters without conversion data
+    test('Verify no conversion attributes', () => {
+        const button = $('#login-button-1')[0];
+        const conversionAttrs = [
+            "linkedin-conversion",
+            "twitter-conversion",
+            "reddit-conversion",
+            "data-analytics",
+            "factor-conversion"
+        ];
+        for (const attr of conversionAttrs) {
+            expect(button.getAttribute(attr)).toBeNull();
+        }
+    });
+
+    // Test basic URL parameters
+    test('Verify basic URL parameters', () => {
+        const button = $('#login-button-1')[0];
+        const href = button.getAttribute('href');
+        const url = new URL(href);
+        // Login buttons should preserve original UTM parameters
+        expect(url.searchParams.get('utm_campaign')).toBe('blah');
+        // But should still add submission URL
+        expect(url.searchParams.get('submission_url')).toBe('/product/soc2');
+    });
+
+    // Test click behavior
+    test('Verify UTM cookie deletion on click', () => {
+        // Clean up any existing cookies
+        delete_utm_cookie();
+
+        // Set up UTM parameters in cookie
+        const params = new URLSearchParams();
+        params.set('utm_source', 'test');
+        setCookie(params);
+
+        // Verify cookie exists
+        expect(get_utm_cookie()).not.toBeNull();
+
+        // Click and verify deletion
+        $('#login-button-1').click();
+        expect(get_utm_cookie()).toBeNull();
+    });
+
+    // Test relative URLs remain unchanged
+    test('Relative link remains unchanged', () => {
+        const href = $('#login-button-bad')[0].getAttribute('href');
+        expect(href).toBe('#login');
+    });
+});

--- a/test/update_trial_links.test.js
+++ b/test/update_trial_links.test.js
@@ -68,7 +68,7 @@ describe("Update Trial Links", () => {
         let attribute1 = $('#trial-button-bad')[0].getAttribute('href');
         expect(attribute1).toBe("#login")
     })
-    test( 'test propagate converstions', () => {
+    test( 'test propagate conversions', () => {
         const entries = Object.entries(window.trial_conversions);
         for ( const [attr, val] of entries){
             let totest = $('#trial-button-1')[0].getAttribute(attr)


### PR DESCRIPTION
Add `login-button` handling. Marketing doesn't want conversion tracking, including segment events on links with the the `login-button` attribute but it should preserve the other tracking data that will get passed to `.io`