### PR TITLE
iOS Cookie Fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export function get_hubspot_cookie() {
 }
 
 export function setCookie(newList) {
-    Cookies.set('chocolate-chip', newList, { expires: 7 })
+    Cookies.set('chocolate-chip', newList, { expires: 7, secure: true, sameSite: 'lax' })
 }
 
 export function endsWithDomain(referringHost, domains) {


### PR DESCRIPTION
Jamie reminded me that I could test the mobile trial flow with the iOS simulator. I did that and was able to replicate the issue of UTMs not being passed on the corporate site. It looks like the `chocolate-chip` cookie isn't currently being set at all on iOS. After some local testing I found that setting the secure and samesite cookie parameters let the cookie actually be set on the simulator. I also tested this set up in Chrome with local overrides and didn't see any issues.