### PR TITLE
Updated the cookie to be set with the domain .nudgesecurity.com for cross-subdomain access.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ export function processHrefTrialParams(
 export function selectAndUpdateTrialButtons() {
     $('[trial-button]').each(function () {
         processHrefTrialParams($(this)[0])
-        $(this).on('click', (e) => {x
+        $(this).on('click', (e) => {
             delete_utm_cookie()
             var url = e.target.getAttribute('href')
             track_event('trial_click_leaving_com', { target: url })


### PR DESCRIPTION
Currently, the cookie used to store the parameters is host-specific. Update the logic to set the cookie using the root domain (.nudgesecurity.com) to enable sharing across subdomains.