### PR TITLE
Fix: Prevent consent-manager reload from skipping UTM cookie creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,8 +129,11 @@ export function process_utm_data() {
         var referringHost = referrer.host
         //Try to detect internal navigation
         if (endsWithDomain(referringHost, ['nudgesecurity.com'])) {
-            // and bail
-            return
+            var existingCookie = get_utm_cookie();
+            if (existingCookie) {
+                 // and bail
+                return
+            }
         }
         newList.set('referring_domain', referringHost)
     }


### PR DESCRIPTION
## Summary
- Fixes a bug where UTM tracking cookies (`chocolate-chip`) are never
  created for first-time visitors who go through the cookie consent flow
- Root cause: the Segment consent manager reloads the page after the user
  accepts cookies, which causes `document.referrer` to be set to the
  current page's own URL (`nudgesecurity.com`). The internal-navigation
  guard in `process_utm_data()` matches this as an internal referrer and
  returns early — before `setCookie()` is ever called
- Fix: check whether the `chocolate-chip` cookie already exists before
  bailing on internal referrers. If the cookie doesn't exist yet, this is
  the first opportunity to capture attribution data, so we proceed. If it
  already exists, we return early to preserve the original UTM values