### PR TITLE
Fix node version for publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
       # actions/setup-node v6.3.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
It looks like the node version we're using installs a version of npm that doesn't support OIDC.